### PR TITLE
feat(models): add to_dict() to Unit model for API serialization (#31)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -40,6 +40,15 @@ class Unit(db.Model):
     reviews  = db.relationship('Review',    backref='unit', lazy=True)
     saved_by = db.relationship('SavedUnit', backref='unit', lazy=True)
 
+    # to_dict() method for easy JSON serialization
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'code': self.code,
+            'name': self.name,
+            'faculty': self.faculty,
+            'credit_points': self.credit_points
+        }
     def __repr__(self):
         return f'<Unit {self.code}>'
 


### PR DESCRIPTION
This update addresses the bug issue raised in #31 to clarify the API endpoint isn't blocked when triggered.

Closes #31 