### PR TITLE
Add unit detail page — HTML layout and CSS styles

### DIFF
--- a/app/static/css/unit.css
+++ b/app/static/css/unit.css
@@ -1,0 +1,234 @@
+/* ── Unit Detail Page ─────────────────────────────── */
+
+.unit-page {
+    min-height: 100vh;
+    background: #f8f9fa;
+}
+
+
+/* Header */
+.unit-header {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    color: #fff;
+    padding: 3rem 0 2.5rem;
+}
+
+.unit-header-inner {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+.unit-meta {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.unit-code {
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    background: rgba(255,255,255,0.15);
+    padding: 0.25rem 0.75rem;
+    border-radius: 20px;
+}
+
+.unit-faculty,
+.unit-credits {
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.65);
+}
+
+.unit-name {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0;
+    line-height: 1.2;
+}
+
+/* Body */
+.unit-body {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.section-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #1a1a2e;
+    margin-bottom: 1.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+/* Score Cards */
+.score-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.score-card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 1.25rem 1.5rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
+.score-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #888;
+    margin-bottom: 0.4rem;
+}
+
+.score-value {
+    font-size: 2rem;
+    font-weight: 800;
+    color: #1a1a2e;
+    line-height: 1;
+    margin-bottom: 0.75rem;
+}
+
+.score-bar-track {
+    height: 6px;
+    background: #eee;
+    border-radius: 99px;
+    overflow: hidden;
+    margin-bottom: 0.4rem;
+}
+
+.score-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #4f8ef7, #7c3aed);
+    border-radius: 99px;
+    transition: width 0.6s ease;
+}
+
+.score-max {
+    font-size: 0.75rem;
+    color: #aaa;
+}
+
+/* Reviews */
+.reviews-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.reviews-header .section-title {
+    margin-bottom: 0;
+}
+
+.review-count {
+    color: #aaa;
+    font-weight: 400;
+}
+
+.write-review-btn {
+    font-size: 0.875rem;
+    padding: 0.5rem 1.25rem;
+}
+
+.review-card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    margin-bottom: 1rem;
+}
+
+.review-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.reviewer-info {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.reviewer-avatar {
+    font-size: 1.5rem;
+    color: #ccc;
+}
+
+.reviewer-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: #1a1a2e;
+}
+
+.reviewer-meta {
+    font-size: 0.8rem;
+    color: #aaa;
+}
+
+.review-overall .fa-star { font-size: 0.9rem; }
+.star-filled { color: #f59e0b; }
+.star-empty  { color: #e5e7eb; }
+
+.review-comment {
+    color: #444;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin-bottom: 1rem;
+}
+
+.review-ratings {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.review-rating-pill {
+    font-size: 0.78rem;
+    background: #f3f4f6;
+    color: #555;
+    padding: 0.25rem 0.75rem;
+    border-radius: 99px;
+}
+
+.review-rating-pill strong {
+    color: #1a1a2e;
+}
+
+/* Empty state */
+.no-reviews {
+    text-align: center;
+    padding: 3rem;
+    color: #aaa;
+    background: #fff;
+    border-radius: 12px;
+}
+
+.no-reviews i {
+    font-size: 2.5rem;
+    margin-bottom: 0.75rem;
+    display: block;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+    .unit-name { font-size: 1.4rem; }
+    .score-cards { grid-template-columns: repeat(2, 1fr); }
+}
+

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -26,7 +26,7 @@
             <div class="score-cards">
                 <div class="score-item">
                 
-                <<div class="score-card">
+                <<div class="score-card">>
                     <div class="score-label">Overall</div>
                     <div class="score-value">{{ "%.1f"|format(unit.avg_overall or 0) }}</div>
                     <div class="score-bar-track">
@@ -35,7 +35,7 @@
                     <div class="score-max">out of 5</div>
                 </div>
 
-                <<div class="score-card">
+                <<div class="score-card">>
                     <div class="score-label">Workload</div>
                     <div class="score-value">{{ "%.1f"|format(unit.avg_workload or 0) }}</div>
                     <div class="score-bar-track">
@@ -44,7 +44,7 @@
                     <div class="score-max">out of 5</div>
                 </div>
 
-                <<div class="score-card">
+                <<div class="score-card">>
                     <div class="score-label">Difficulty</div>
                     <div class="score-value">{{ "%.1f"|format(unit.avg_difficulty or 0) }}</div>
                     <div class="score-bar-track">
@@ -53,7 +53,7 @@
                     <div class="score-max">out of 5</div>
                 </div>
 
-                <<div class="score-card">
+                <<div class="score-card">>
                     <div class="score-label">Usefulness</div>
                     <div class="score-value">{{ "%.1f"|format(unit.avg_usefulness or 0) }}</div>
                     <div class="score-bar-track">

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -6,6 +6,19 @@
 
 {% block content %}
 <div class="unit-page"
-    <p>Unit detail page — coming soon</p>
+
+    <!-- Unit Header -->
+    <div class="unit-header">
+        <div class="unit-header-inner">
+            <div class="unit-meta">
+                <span class="unit-code">{{ unit.code }}</span>
+                <span class="unit-faculty">{{ unit.faculty | capitalize }}</span>
+                <span class="unit-credits">{{ unit.credit_points }} credit points</span>
+            </div>
+        <h1 class="unit-name">{{ unit.name }}</h1>
+        </div>
+    </div>
+
+
 </div>
 {% endblock %}

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -19,6 +19,51 @@
         </div>
     </div>
 
+    <!-- Unit Details -->
+    <div class="unit-body">
+        <section class="score-section">
+            <h2 class="section-title">Ratings</h2>
+            <div class="score-cards">
+                <div class="score-item">
+                
+                <<div class="score-card">
+                    <div class="score-label">Overall</div>
+                    <div class="score-value">{{ "%.1f"|format(unit.avg_overall or 0) }}</div>
+                    <div class="score-bar-track">
+                        <div class="score-bar-fill" style="width: {{ ((unit.avg_overall or 0) / 5 * 100)|int }}%"></div>
+                    </div>
+                    <div class="score-max">out of 5</div>
+                </div>
 
+                <<div class="score-card">
+                    <div class="score-label">Workload</div>
+                    <div class="score-value">{{ "%.1f"|format(unit.avg_workload or 0) }}</div>
+                    <div class="score-bar-track">
+                        <div class="score-bar-fill" style="width: {{ ((unit.avg_workload or 0) / 5 * 100)|int }}%"></div>
+                    </div>
+                    <div class="score-max">out of 5</div>
+                </div>
+
+                <<div class="score-card">
+                    <div class="score-label">Difficulty</div>
+                    <div class="score-value">{{ "%.1f"|format(unit.avg_difficulty or 0) }}</div>
+                    <div class="score-bar-track">
+                        <div class="score-bar-fill" style="width: {{ ((unit.avg_difficulty or 0) / 5 * 100)|int }}%"></div>
+                    </div>
+                    <div class="score-max">out of 5</div>
+                </div>
+
+                <<div class="score-card">
+                    <div class="score-label">Usefulness</div>
+                    <div class="score-value">{{ "%.1f"|format(unit.avg_usefulness or 0) }}</div>
+                    <div class="score-bar-track">
+                        <div class="score-bar-fill" style="width: {{ ((unit.avg_usefulness or 0) / 5 * 100)|int }}%"></div>
+                    </div>
+                    <div class="score-max">out of 5</div>
+                </div>
+            </div>
+        </section>
+
+    </div>
 </div>
 {% endblock %}

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -64,6 +64,36 @@
             </div>
         </section>
 
+
+        <!-- Reviews Section -->
+        <section class="reviews-section">
+            <h2 class="section-title">Student Reviews</h2>
+            {% if reviews %}
+                <div class="reviews-list">
+                    {% for review in reviews %}
+                        <div class="review-card">
+                            <div class="review-header">
+                                <span class="reviewer-name">{{ review.author.username }}</span>
+                                <span class="review-date">{{ review.created_at.strftime('%Y-%m-%d') }}</span>
+                            </div>
+                            <div class="review-scores">
+                                <div class="review-score-item">Overall: {{ review.overall_rating }}</div>
+                                <div class="review-score-item">Workload: {{ review.workload_rating }}</div>
+                                <div class="review-score-item">Difficulty: {{ review.difficulty_rating }}</div>
+                                <div class="review-score-item">Usefulness: {{ review.usefulness_rating }}</div>
+                            </div>
+                            <p class="review-comment">{{ review.comment }}</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <p class="no-reviews"> No reviews yet. Be the first to review this unit!</p>
+            {% endif %}
+
+            <a href = "#" class<a href="#" class="ur-btn ur-btn-primary write-review-btn">
+                Write a Review
+            </a>
+        </section>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="unit-page"
+<div class="unit-page">
 
     <!-- Unit Header -->
     <div class="unit-header">

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/unit.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="unit-page"
+    <p>Unit detail page — coming soon</p>
+</div>
+{% endblock %}

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -90,9 +90,7 @@
                 <p class="no-reviews"> No reviews yet. Be the first to review this unit!</p>
             {% endif %}
 
-            <a href = "#" class<a href="#" class="ur-btn ur-btn-primary write-review-btn">
-                Write a Review
-            </a>
+            <a href="#" class="ur-btn ur-btn-primary write-review-btn">Write a Review</a>
         </section>
     </div>
 </div>

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -26,7 +26,7 @@
             <div class="score-cards">
                 <div class="score-item">
                 
-                <<div class="score-card">>
+                <div class="score-card">
                     <div class="score-label">Overall</div>
                     <div class="score-value">{{ "%.1f"|format(unit.avg_overall or 0) }}</div>
                     <div class="score-bar-track">
@@ -35,7 +35,7 @@
                     <div class="score-max">out of 5</div>
                 </div>
 
-                <<div class="score-card">>
+                <div class="score-card">
                     <div class="score-label">Workload</div>
                     <div class="score-value">{{ "%.1f"|format(unit.avg_workload or 0) }}</div>
                     <div class="score-bar-track">
@@ -44,7 +44,7 @@
                     <div class="score-max">out of 5</div>
                 </div>
 
-                <<div class="score-card">>
+                <div class="score-card">
                     <div class="score-label">Difficulty</div>
                     <div class="score-value">{{ "%.1f"|format(unit.avg_difficulty or 0) }}</div>
                     <div class="score-bar-track">
@@ -53,7 +53,7 @@
                     <div class="score-max">out of 5</div>
                 </div>
 
-                <<div class="score-card">>
+                <div class="score-card">
                     <div class="score-label">Usefulness</div>
                     <div class="score-value">{{ "%.1f"|format(unit.avg_usefulness or 0) }}</div>
                     <div class="score-bar-track">


### PR DESCRIPTION
## What this PR does
Implements the static design for the unit detail page (`/unit/<code>`), covering the full HTML layout and CSS styles.

## Files added
- `templates/unit.html` — extends base.html, full unit detail page layout
- `static/css/unit.css` — styles for the unit detail page

## Changes include
- Unit header showing unit code, name, faculty and credit points
- Four score cards (overall, workload, difficulty, usefulness) with rating bars
- Student reviews list with reviewer name, date, scores and comment
- Empty state message when no reviews exist
- Write a Review button placeholder
- Responsive layout for mobile screens

## Notes
- Template variables (`unit`, `reviews`) are placeholders — Nevis will wire up the Flask route with real database data
- Closes #10 