### PR TITLE
Feature: Implemented Review submit, delete, edit routes.

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3,7 +3,7 @@ from flask_login import login_user, logout_user, current_user, login_required
 from werkzeug.security import generate_password_hash, check_password_hash
 from app.forms import LoginForm, RegisterForm, ReviewForm
 from app import db
-from app.models import User, Unit, Review
+from app.models import User, Unit, Review, Vote
 
 main = Blueprint('main', __name__)
 
@@ -147,3 +147,85 @@ def unit_detail(code):
                            is_saved=is_saved,
                            similar_units=similar_units,
                            form=form)
+
+# Submit a review
+@main.route('/review/submit', methods=['POST'])
+@login_required
+def submit_review():
+    form = ReviewForm()
+    unit_code = request.form.get('unit_code')
+    unit = Unit.query.filter_by(code=unit_code).first_or_404()
+
+    # Enforce one review per student per unit
+    existing = Review.query.filter_by(
+        unit_id=unit.id, user_id=current_user.id
+    ).first()
+    if existing:
+        flash('You have already reviewed this unit.', 'warning')
+        return redirect(url_for('main.unit_detail', code=unit.code))
+
+    if form.validate_on_submit():
+        review = Review(
+            user_id           = current_user.id,
+            unit_id           = unit.id,
+            overall_rating    = form.overall_rating.data,
+            workload_rating   = form.workload_rating.data,
+            difficulty_rating = form.difficulty_rating.data,
+            usefulness_rating = form.usefulness_rating.data,
+            comment           = form.comment.data,
+            year_taken        = int(request.form.get('year_taken', 2024)),
+            semester          = request.form.get('semester', 'S1')
+        )
+        db.session.add(review)
+        db.session.commit()
+        flash('Your review has been posted!', 'success')
+    else:
+        flash('Please fix the errors in your review.', 'danger')
+
+    return redirect(url_for('main.unit_detail', code=unit.code))
+
+
+# Edit a review
+@main.route('/review/edit/<int:review_id>', methods=['POST'])
+@login_required
+def edit_review(review_id):
+    review = Review.query.get_or_404(review_id)
+
+    # Only the owner can edit
+    if review.user_id != current_user.id:
+        flash('You can only edit your own reviews.', 'danger')
+        return redirect(url_for('main.unit_detail', code=review.unit.code))
+
+    form = ReviewForm()
+    if form.validate_on_submit():
+        review.overall_rating    = form.overall_rating.data
+        review.workload_rating   = form.workload_rating.data
+        review.difficulty_rating = form.difficulty_rating.data
+        review.usefulness_rating = form.usefulness_rating.data
+        review.comment           = form.comment.data
+        db.session.commit()
+        flash('Your review has been updated.', 'success')
+    else:
+        flash('Please fix the errors in your review.', 'danger')
+
+    return redirect(url_for('main.unit_detail', code=review.unit.code))
+
+
+# Delete a review
+@main.route('/review/delete/<int:review_id>', methods=['POST'])
+@login_required
+def delete_review(review_id):
+    review = Review.query.get_or_404(review_id)
+
+    # Only the owner can delete
+    if review.user_id != current_user.id:
+        flash('You can only delete your own reviews.', 'danger')
+        return redirect(url_for('main.unit_detail', code=review.unit.code))
+
+    unit_code = review.unit.code
+    # Delete associated votes first
+    Vote.query.filter_by(review_id=review_id).delete()
+    db.session.delete(review)
+    db.session.commit()
+    flash('Your review has been deleted.', 'info')
+    return redirect(url_for('main.unit_detail', code=unit_code))

--- a/app/static/js/unit.js
+++ b/app/static/js/unit.js
@@ -2,10 +2,41 @@
 
 $(document).ready(function () {
 
-    /* ── Toggle review form (delegated handler) ────────────── */
+    /* Toggle review form */
     $(document).on('click', '.js-toggle-review-form', function (e) {
         e.preventDefault();
+        // Reset form to submit (not edit) mode
+        var $form = $('#review-form form');
+        $form.attr('action', $form.data('submit-url'));
+        $('#review-form-title').text('Your review');
         $('#review-form').slideToggle(200);
+    });
+
+    /* Edit review button */
+    $(document).on('click', '.js-edit-review', function () {
+        var reviewId = $(this).data('review-id');
+        var $card    = $('#review-' + reviewId);
+
+        // Read existing values from the review card
+        var overall    = parseInt($card.find('.review-score-badge').text().match(/\d+/)[0]);
+        var miniStats  = $card.find('.review-mini-stat strong');
+        var workload   = parseInt($(miniStats[0]).text());
+        var difficulty = parseInt($(miniStats[1]).text());
+        var usefulness = parseInt($(miniStats[2]).text());
+        var comment    = $card.find('.review-comment').text().trim();
+
+        // Pre-fill the form
+        $('#slider-overall').val(overall);    $('#val-overall').text(overall);
+        $('#slider-workload').val(workload);   $('#val-workload').text(workload);
+        $('#slider-difficulty').val(difficulty); $('#val-difficulty').text(difficulty);
+        $('#slider-usefulness').val(usefulness); $('#val-usefulness').text(usefulness);
+        $('textarea[name="comment"]').val(comment);
+
+        // Change form action to edit endpoint
+        $('#review-form form').attr('action', '/review/edit/' + reviewId);
+        $('#review-form-title').text('Edit your review');
+        $('#review-form').slideDown(200);
+        $('#review-form')[0].scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
 
     /* ── Vote buttons (upvote / downvote) ──────────────────── */

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -107,12 +107,15 @@
       </div>
 
       <!-- ── Review form (hidden by default) ─────────────── -->
-      {% if current_user.is_authenticated and not user_has_reviewed %}
+      {% if current_user.is_authenticated %}
       <div class="unit-review-form" id="review-form" style="display:none">
-        <h3 class="review-form-title">Your review for {{ unit.code }}</h3>
+        <h3 class="review-form-title" id="review-form-title">Your review for {{ unit.code }}</h3>
 
-        <form method="POST" action="#" novalidate>
+        <form method="POST" action="{{ url_for('main.submit_review') }}"
+        data-submit-url="{{ url_for('main.submit_review') }}"
+        novalidate>
           {{ form.hidden_tag() }}
+          <input type="hidden" name="unit_code" value="{{ unit.code }}">
 
           <!-- Rating sliders -->
           <div class="rating-grid">
@@ -246,7 +249,7 @@
                 <i class="fa-solid fa-pen"></i> Edit
               </button>
               <form method="POST"
-                    action="#"
+                    action="{{ url_for('main.delete_review', review_id=review.id) }}"
                     class="d-inline"
                     onsubmit="return confirm('Delete your review?')">
                 {{ form.hidden_tag() }}


### PR DESCRIPTION
## What this PR does
Implements review submission, editing, and deletion routes for Issue #11.

## New routes in routes.py
- `POST /review/submit` — validates ReviewForm and saves a new Review 
  to the database. Backend check enforces one review per user per unit 
  in case a request bypasses the UI (the "Write a review" button is 
  hidden for users who have already reviewed, so this flash will only 
  appear for edge cases like direct API calls). Redirects to the unit 
  page on success.
- `POST /review/edit/<int:review_id>` — updates an existing review's 
  ratings and comment. Only the review's author can edit; others 
  receive a flash error.
- `POST /review/delete/<int:review_id>` — deletes a review and its 
  associated votes. Only the author can delete.
- All three routes have `@login_required` so unauthenticated users 
  are redirected to login.

## Modified files
- `app/routes.py` — added three new routes, imported Vote model
- `app/templates/unit.html` — updated form actions to use real routes 
  instead of `#`, added hidden `unit_code` input on submit form
- `app/static/js/unit.js` — added Edit button handler that pre-fills 
  the review form with existing values and switches the form action 
  to the edit endpoint

## How to test
1. Log in with any account
2. Navigate to a unit detail page (e.g. `/unit/CITS5505`)
3. Click "Write a review" → form opens with sliders defaulting to 3
<img width="1458" height="716" alt="Screenshot 2026-05-06 at 1 44 21 am" src="https://github.com/user-attachments/assets/3a6929a9-7c5b-4ce8-8ef6-b4b2df621612" />

4. Submit a review with valid ratings + comment (20+ chars) → 
   success flash, review appears at top of list, "Write a review" 
   button disappears
<img width="1470" height="697" alt="Screenshot 2026-05-06 at 1 47 14 am" src="https://github.com/user-attachments/assets/8c8d8c2d-55ca-4c78-aa7a-a21d0dee6a79" />
 
5. Refresh the page — verify the review persisted in the database
6. Click "Edit" on your review → form opens pre-filled with your 
   existing values
<img width="1451" height="739" alt="Screenshot 2026-05-06 at 1 48 42 am" src="https://github.com/user-attachments/assets/05b31bcc-d89f-4b60-ba61-b6a3128f9a4d" />

7. Change the ratings/comment and submit → review updates on page
8. Click "Delete" → confirm dialog → review is removed, "Write a 
   review" button reappears
   <img width="1276" height="624" alt="Screenshot 2026-05-06 at 1 49 25 am" src="https://github.com/user-attachments/assets/9d4ba025-c7c1-4116-b3d4-ccb98f91aa2a" />

9. Log in as a different user, navigate to the same unit, try 
   editing/deleting the first user's review by manually constructing 
   the URL (e.g. `/review/edit/1`) → flash error "you can only 
   edit/delete your own reviews"
   Note: This is a security backend issue cannot be tested from frontend as "delete" button is set disabled.

## Closes
Closes #11