### PR TITLE
feat: save and unsave unit feature (#13)

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -238,6 +238,9 @@ def delete_review(review_id):
 @login_required
 def save_unit():
     unit_id = request.json.get('unit_id')
+    if not unit_id:
+        return jsonify({'error': 'unit_id is required'}), 400
+    Unit.query.get_or_404(unit_id)
     existing = SavedUnit.query.filter_by(
         user_id=current_user.id, unit_id=unit_id
     ).first()

--- a/app/routes.py
+++ b/app/routes.py
@@ -3,7 +3,7 @@ from flask_login import login_user, logout_user, current_user, login_required
 from werkzeug.security import generate_password_hash, check_password_hash
 from app.forms import LoginForm, RegisterForm, ReviewForm
 from app import db
-from app.models import User, Unit, Review, Vote
+from app.models import User, Unit, Review, Vote, SavedUnit
 
 main = Blueprint('main', __name__)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -230,7 +230,7 @@ def delete_review(review_id):
     flash('Your review has been deleted.', 'info')
     return redirect(url_for('main.unit_detail', code=unit_code))
 
-# Save/unsave a unit
+# Save/unsave a unit (AJAX)
 @main.route('/api/save-unit', methods=['POST'])
 @login_required
 def save_unit():
@@ -247,3 +247,11 @@ def save_unit():
         db.session.add(save)
         db.session.commit()
         return jsonify({'saved': True})
+
+# Saved units page
+@main.route('/saved-units')
+@login_required
+def saved_units():
+    saved = SavedUnit.query.filter_by(user_id=current_user.id).all()
+    units = [s.unit for s in saved]
+    return render_template('saved_units.html', units=units)

--- a/app/routes.py
+++ b/app/routes.py
@@ -128,6 +128,9 @@ def unit_detail(code):
         user_has_reviewed = Review.query.filter_by(
             unit_id=unit.id, user_id=current_user.id
         ).first() is not None
+        is_saved = SavedUnit.query.filter_by(
+            user_id=current_user.id, unit_id=unit.id
+        ).first() is not None
 
     similar_units = Unit.query.filter(
         Unit.faculty == unit.faculty, Unit.id != unit.id

--- a/app/routes.py
+++ b/app/routes.py
@@ -229,3 +229,21 @@ def delete_review(review_id):
     db.session.commit()
     flash('Your review has been deleted.', 'info')
     return redirect(url_for('main.unit_detail', code=unit_code))
+
+# Save/unsave a unit
+@main.route('/api/save-unit', methods=['POST'])
+@login_required
+def save_unit():
+    unit_id = request.json.get('unit_id')
+    existing = SavedUnit.query.filter_by(
+        user_id=current_user.id, unit_id=unit_id
+    ).first()
+    if existing:
+        db.session.delete(existing)
+        db.session.commit()
+        return jsonify({'saved': False})
+    else:
+        save = SavedUnit(user_id=current_user.id, unit_id=unit_id)
+        db.session.add(save)
+        db.session.commit()
+        return jsonify({'saved': True})

--- a/app/static/css/saved.css
+++ b/app/static/css/saved.css
@@ -1,96 +1,61 @@
 /* ─── Saved units page ───────────────────────────────────────── */
 
-/* ── Page header ────────────────────────────────────────────── */
-.saved-page-header {
-  padding: 28px 48px 0;
-  max-width: 1200px;
-  margin: 0 auto;
+.saved-page {
+  padding-bottom: 4rem;
 }
 
-.saved-page-title {
-  font-size: 1.5rem;
+/* ── Hero ───────────────────────────────────────────────────── */
+.saved-hero {
+  padding: 36px 48px 28px;
+  background: var(--white);
+  border-bottom: 1px solid var(--gray-100);
+}
+
+.saved-hero-name {
+  font-size: 1.75rem;
   font-weight: 700;
   color: var(--gray-900);
-  margin-bottom: 4px;
+  margin: 0 0 4px;
+  line-height: 1.25;
 }
 
-.saved-page-subtitle {
+.saved-hero-meta {
+  margin: 0;
   font-size: .875rem;
   color: var(--gray-500);
-  margin-bottom: 24px;
 }
 
-/* ── Grid ───────────────────────────────────────────────────── */
-.saved-units-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 16px;
-  padding: 24px 48px;
+/* ── Content area ───────────────────────────────────────────── */
+.saved-content {
   max-width: 1200px;
   margin: 0 auto;
+  padding: 28px 48px;
 }
 
-/* ── Unit card ──────────────────────────────────────────────── */
-.saved-unit-card {
-  display: block;
-  background: var(--white);
-  border: 1px solid var(--gray-100);
-  border-radius: var(--radius-lg);
-  padding: 18px 20px;
-  text-decoration: none;
-  transition: box-shadow var(--transition);
-  box-shadow: var(--shadow-sm);
-}
-.saved-unit-card:hover { box-shadow: var(--shadow-md); }
-
-.saved-unit-code {
-  font-size: .75rem;
-  font-weight: 700;
-  color: var(--blue-600);
-  letter-spacing: .06em;
-  text-transform: uppercase;
-  margin-bottom: 6px;
-}
-
-.saved-unit-name {
-  font-size: .9375rem;
-  font-weight: 600;
-  color: var(--gray-900);
-  margin-bottom: 6px;
-  line-height: 1.3;
-}
-
-.saved-unit-faculty {
-  font-size: .8125rem;
-  color: var(--gray-500);
-}
-
-/* ── Empty state ────────────────────────────────────────────── */
-.saved-empty {
+/* ── Empty state (matches profile page pattern) ─────────────── */
+.review-empty {
   text-align: center;
   padding: 56px 24px;
   color: var(--gray-500);
   background: var(--white);
   border: 1px solid var(--gray-100);
   border-radius: var(--radius-lg);
-  margin: 24px 48px;
 }
 
-.saved-empty i {
+.review-empty i {
   font-size: 2.25rem;
   margin-bottom: 12px;
   display: block;
   color: var(--gray-300);
 }
 
-.saved-empty p { font-size: .9375rem; margin-bottom: 16px; }
+.review-empty p {
+  font-size: .9375rem;
+  margin-bottom: 16px;
+}
 
 /* ── Responsive ─────────────────────────────────────────────── */
 @media (max-width: 960px) {
-  .saved-page-header { padding: 20px 24px 0; }
-  .saved-units-grid  { padding: 20px 24px; }
-}
-
-@media (max-width: 600px) {
-  .saved-units-grid { grid-template-columns: 1fr; }
+  .saved-hero    { padding: 24px; }
+  .saved-content { padding: 20px 24px; }
 }

--- a/app/static/css/saved.css
+++ b/app/static/css/saved.css
@@ -1,0 +1,96 @@
+/* ─── Saved units page ───────────────────────────────────────── */
+
+/* ── Page header ────────────────────────────────────────────── */
+.saved-page-header {
+  padding: 28px 48px 0;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.saved-page-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--gray-900);
+  margin-bottom: 4px;
+}
+
+.saved-page-subtitle {
+  font-size: .875rem;
+  color: var(--gray-500);
+  margin-bottom: 24px;
+}
+
+/* ── Grid ───────────────────────────────────────────────────── */
+.saved-units-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+  padding: 24px 48px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* ── Unit card ──────────────────────────────────────────────── */
+.saved-unit-card {
+  display: block;
+  background: var(--white);
+  border: 1px solid var(--gray-100);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+  text-decoration: none;
+  transition: box-shadow var(--transition);
+  box-shadow: var(--shadow-sm);
+}
+.saved-unit-card:hover { box-shadow: var(--shadow-md); }
+
+.saved-unit-code {
+  font-size: .75rem;
+  font-weight: 700;
+  color: var(--blue-600);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.saved-unit-name {
+  font-size: .9375rem;
+  font-weight: 600;
+  color: var(--gray-900);
+  margin-bottom: 6px;
+  line-height: 1.3;
+}
+
+.saved-unit-faculty {
+  font-size: .8125rem;
+  color: var(--gray-500);
+}
+
+/* ── Empty state ────────────────────────────────────────────── */
+.saved-empty {
+  text-align: center;
+  padding: 56px 24px;
+  color: var(--gray-500);
+  background: var(--white);
+  border: 1px solid var(--gray-100);
+  border-radius: var(--radius-lg);
+  margin: 24px 48px;
+}
+
+.saved-empty i {
+  font-size: 2.25rem;
+  margin-bottom: 12px;
+  display: block;
+  color: var(--gray-300);
+}
+
+.saved-empty p { font-size: .9375rem; margin-bottom: 16px; }
+
+/* ── Responsive ─────────────────────────────────────────────── */
+@media (max-width: 960px) {
+  .saved-page-header { padding: 20px 24px 0; }
+  .saved-units-grid  { padding: 20px 24px; }
+}
+
+@media (max-width: 600px) {
+  .saved-units-grid { grid-template-columns: 1fr; }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -36,7 +36,7 @@
       <a href="{{ url_for('main.index') }}" class="ur-nav-link">Browse</a>
       <a href="#" class="ur-nav-link">My reviews</a>
       {% if current_user.is_authenticated %}
-      <a href="{{ url_for('main.saved_units') }}" class="ur-nav-link">Saved</a>
+      <a href="{{ url_for('main.saved_units') }}" class="ur-nav-link">Saved Units</a>
       <span class="ur-nav-link">Hi, {{ current_user.username }}</span>
       <a href="{{ url_for('main.logout') }}" class="ur-btn ur-btn-outline">Log out</a>
       {% else %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -37,7 +37,7 @@
       {% if current_user.is_authenticated %}
       <a href="{{ url_for('main.saved_units') }}" class="ur-nav-link">Saved Units</a>
       <a href="{{ url_for('main.profile', username=current_user.username) }}" class="ur-nav-link">
-      Hi, {{ current_user.username }}
+        Hi, {{ current_user.username }}
       </a>
       <a href="{{ url_for('main.logout') }}" class="ur-btn ur-btn-outline">Log out</a>
       {% else %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -36,6 +36,7 @@
       <a href="{{ url_for('main.index') }}" class="ur-nav-link">Browse</a>
       <a href="#" class="ur-nav-link">My reviews</a>
       {% if current_user.is_authenticated %}
+      <a href="{{ url_for('main.saved_units') }}" class="ur-nav-link">Saved</a>
       <span class="ur-nav-link">Hi, {{ current_user.username }}</span>
       <a href="{{ url_for('main.logout') }}" class="ur-btn ur-btn-outline">Log out</a>
       {% else %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,7 @@
     <div class="ur-navbar-links">
       <a href="{{ url_for('main.index') }}" class="ur-nav-link">Browse</a>
       {% if current_user.is_authenticated %}
-      <a href="{{ url_for('main.saved_units') }}" class="ur-nav-link">Saved Units</a>
+      <a href="{{ url_for('main.saved_units') }}" class="ur-nav-link">Saved units</a>
       <a href="{{ url_for('main.profile', username=current_user.username) }}" class="ur-nav-link">
         Hi, {{ current_user.username }}
       </a>

--- a/app/templates/saved_units.html
+++ b/app/templates/saved_units.html
@@ -1,20 +1,31 @@
 {% extends "base.html" %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/saved.css') }}">
+{% endblock %}
+
 {% block content %}
-<div class="saved-units-page">
-    <h1>My Saved Units</h1>
-    {% if units %}
-        <div class="unit-grid">
-            {% for unit in units %}
-            <a href="{{ url_for('main.unit_detail', code=unit.code) }}" class="ur-unit-card">
-                <div class="ur-unit-code">{{ unit.code }}</div>
-                <div class="ur-unit-name">{{ unit.name }}</div>
-                <div class="ur-unit-faculty">{{ unit.faculty }}</div>
-            </a>
-            {% endfor %}
-        </div>
-    {% else %}
-        <p>You haven't saved any units yet. <a href="{{ url_for('main.index') }}">Browse units</a></p>
-    {% endif %}
+<div class="saved-page-header">
+    <h1 class="saved-page-title">My Saved Units</h1>
+    <p class="saved-page-subtitle">Units you have bookmarked for later</p>
 </div>
+
+{% if units %}
+<div class="saved-units-grid">
+    {% for unit in units %}
+    <a href="{{ url_for('main.unit_detail', code=unit.code) }}" class="saved-unit-card">
+        <div class="saved-unit-code">{{ unit.code }}</div>
+        <div class="saved-unit-name">{{ unit.name }}</div>
+        <div class="saved-unit-faculty">{{ unit.faculty }}</div>
+    </a>
+    {% endfor %}
+</div>
+{% else %}
+<div class="saved-empty">
+    <i class="fa-regular fa-bookmark"></i>
+    <p>You haven't saved any units yet.</p>
+    <a href="{{ url_for('main.index') }}" class="ur-btn ur-btn-primary">Browse units</a>
+</div>
+{% endif %}
+
 {% endblock %}

--- a/app/templates/saved_units.html
+++ b/app/templates/saved_units.html
@@ -1,31 +1,56 @@
 {% extends "base.html" %}
 
 {% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/saved.css') }}">
 {% endblock %}
 
 {% block content %}
-<div class="saved-page-header">
-    <h1 class="saved-page-title">My Saved Units</h1>
-    <p class="saved-page-subtitle">Units you have bookmarked for later</p>
-</div>
+<div class="saved-page">
 
-{% if units %}
-<div class="saved-units-grid">
-    {% for unit in units %}
-    <a href="{{ url_for('main.unit_detail', code=unit.code) }}" class="saved-unit-card">
-        <div class="saved-unit-code">{{ unit.code }}</div>
-        <div class="saved-unit-name">{{ unit.name }}</div>
-        <div class="saved-unit-faculty">{{ unit.faculty }}</div>
-    </a>
-    {% endfor %}
-</div>
-{% else %}
-<div class="saved-empty">
-    <i class="fa-regular fa-bookmark"></i>
-    <p>You haven't saved any units yet.</p>
-    <a href="{{ url_for('main.index') }}" class="ur-btn ur-btn-primary">Browse units</a>
-</div>
-{% endif %}
+  {% set crumbs = [
+    ('Browse', url_for('main.index')),
+    ('Saved units', None)
+  ] %}
+  {% include '_breadcrumb.html' %}
 
+  <div class="saved-hero">
+    <h1 class="saved-hero-name">My saved units</h1>
+    <p class="saved-hero-meta">
+      {% if units %}
+        {{ units|length }} unit{{ 's' if units|length != 1 }} bookmarked for later
+      {% else %}
+        Nothing saved yet
+      {% endif %}
+    </p>
+  </div>
+
+  <div class="saved-content">
+
+    {% if units %}
+      <div class="ur-unit-grid">
+        {% for unit in units %}
+        <a href="{{ url_for('main.unit_detail', code=unit.code) }}" class="ur-unit-card">
+          <div class="ur-unit-code">{{ unit.code }}</div>
+          <div class="ur-unit-name">{{ unit.name }}</div>
+          <div class="ur-unit-faculty">{{ unit.faculty }}</div>
+          <div class="ur-unit-footer">
+            <span class="ur-unit-reviews">
+              {{ unit.reviews|length }} review{{ 's' if unit.reviews|length != 1 }}
+            </span>
+            <span class="ur-unit-arrow">&#8594;</span>
+          </div>
+        </a>
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="review-empty">
+        <i class="fa-regular fa-bookmark"></i>
+        <p>You haven't saved any units yet.</p>
+        <a href="{{ url_for('main.index') }}" class="ur-btn ur-btn-primary">Browse units</a>
+      </div>
+    {% endif %}
+
+  </div>
+</div>
 {% endblock %}

--- a/app/templates/saved_units.html
+++ b/app/templates/saved_units.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="saved-units-page">
+    <h1>My Saved Units</h1>
+    {% if units %}
+        <div class="unit-grid">
+            {% for unit in units %}
+            <a href="{{ url_for('main.unit_detail', code=unit.code) }}" class="ur-unit-card">
+                <div class="ur-unit-code">{{ unit.code }}</div>
+                <div class="ur-unit-name">{{ unit.name }}</div>
+                <div class="ur-unit-faculty">{{ unit.faculty }}</div>
+            </a>
+            {% endfor %}
+        </div>
+    {% else %}
+        <p>You haven't saved any units yet. <a href="{{ url_for('main.index') }}">Browse units</a></p>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## What this PR does

- Adds POST /api/save-unit route — toggles saved state using SavedUnit model
- Adds GET /saved-units route — lists all saved units for current user
- Creates saved_units.html template with grid layout and empty state
- Adds saved.css styling matching project design system
- Adds Saved link to navbar visible only to logged-in users
- Fixes is_saved variable in unit_detail to check database instead of hardcoded False

## Files modified

| File | Change |
|------|--------|
| app/routes.py | Add /api/save-unit and /saved-units routes, fix is_saved check |
| app/templates/saved_units.html | New template listing bookmarked units |
| app/static/css/saved.css | Styling for saved units page |
| app/templates/base.html | Add Saved navbar link for logged-in users |

## Notes

- unit.js save button AJAX handler was already implemented by Nidhi in unit page PR
- CSRF protection handled via X-CSRFToken header in unit.js
- Save state reflected on unit detail page initial load via is_saved variable

## How to test

*Step 1-3 if testing in a fresh machine:
1. pip install -r requirements.txt
2. flask db upgrade 
3. python seed.py
4. python run.py
5. Log in and visit any unit page — Save unit button visible
6. Click Save unit — button changes to Saved, row inserted in saved_units table
7. Click Saved — button changes back to Save unit, row deleted from saved_units table
8. Visit http://127.0.0.1:5000/saved-units — shows saved units grid
9. Visit /saved-units without logging in — redirects to login
10. Log out — Saved link disappears from navbar
11. Saved units persist after logout and re-login

## Closes #13