### PR TITLE
feat: display real aggregated scores on unit cards and detail page (#14)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2,6 +2,8 @@
 # models.py
 # Database models for UWA UniReview.
 
+from itertools import count
+
 from app import db
 from datetime import datetime
 from flask_login import UserMixin
@@ -43,20 +45,26 @@ class Unit(db.Model):
 
     # to_dict() method for easy JSON serialization
     def to_dict(self):
+        count = len(self.reviews)
+        if count > 0:
+            avg_overall  = round(sum(r.overall_rating  for r in self.reviews) / count, 1)
+            avg_workload = round(sum(r.workload_rating for r in self.reviews) / count, 1)
+        else:
+            avg_overall  = 0
+            avg_workload = 0
         return {
             'id':            self.id,
             'code':          self.code,
             'name':          self.name,
             'faculty':       self.faculty,
             'credit_points': self.credit_points,
-            'overall':       0,
-            'workload':      0,
-            'reviews':       0
+            'overall':       avg_overall,
+            'workload':      avg_workload,
+            'reviews':       count
         }
         
     def __repr__(self):
         return f'<Unit {self.code}>'
-
 
 class Review(db.Model):
     __tablename__ = 'reviews'

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -7,12 +7,14 @@ $(document).ready(function () {
 
     /* ── Score pill helper ─────────────────────────────────── */
     function scorePill(val) {
+        if (!val || val === 0) return '<span class="score-pill score-none">No reviews yet</span>';
         var cls = val >= 4.2 ? 'score-high' : val >= 3.5 ? 'score-mid' : 'score-low';
         return '<span class="score-pill ' + cls + '">&#9733; ' + val.toFixed(1) + '</span>';
     }
 
     /* ── Workload pill helper ──────────────────────────────── */
     function workloadPill(val) {
+        if (!val || val === 0) return '';
         var cls   = val >= 3.8 ? 'score-high' : val >= 3.0 ? 'score-mid' : 'score-low';
         var label = val >= 3.8 ? 'Light load'  : val >= 3.0 ? 'Moderate'   : 'Heavy load';
         return '<span class="score-pill ' + cls + '">' + label + '</span>';
@@ -47,7 +49,7 @@ $(document).ready(function () {
                     workloadPill(u.workload) +
                   '</div>' +
                   '<div class="ur-unit-footer">' +
-                    '<span class="ur-unit-reviews">' + u.reviews + ' reviews</span>' +
+                    '<span class="ur-unit-reviews">' + (u.reviews > 0 ? u.reviews + ' review' + (u.reviews !== 1 ? 's' : '') : 'Be the first to review') + '</span>' +
                     '<span class="ur-unit-arrow">&#8594;</span>' +
                   '</div>' +
                 '</a>';


### PR DESCRIPTION
## What this PR does

- Updates Unit.to_dict() to calculate real average overall and workload 
  ratings from self.reviews instead of returning hardcoded zeros
- Includes review count in to_dict() output
- Returns zeros gracefully when unit has no reviews (avoids divide-by-zero)
- Updates dashboard.js to show "No reviews yet" and "Be the first to review"
  instead of "★ 0.0" and "Heavy load" for unreviewed units

## Files modified

| File | Change |
|------|--------|
| app/models.py | Update Unit.to_dict() to compute averages from self.reviews |
| app/static/js/dashboard.js | Handle units with no reviews gracefully |

## How to test

1. python run.py
2. Visit http://127.0.0.1:5000 — units with reviews show real ratings
3. Units with no reviews show "No reviews yet" and "Be the first to review"
4. Search for CITS — cards show real ratings in search results
5. Faculty filter still works correctly
6. Visit a unit detail page — averages still display correctly

## Notes
- Dashboard stats bar (Units listed, Reviews written, Avg overall score) 
  is a separate issue and not in scope here

## Closes #14