### PR TITLE
add Chart.js rating distribution chart to unit detail sidebar (#16)

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -151,7 +151,7 @@ def unit_detail(code):
     ).limit(4).all()
 
     # Count reviews per star value (1–5) for the Chart.js bar chart
-    rating_dist = [
+    overall_rating_dist = [
         sum(1 for r in reviews_raw if r.overall_rating is not None and r.overall_rating == star)
         for star in range(1, 6)
     ]
@@ -169,7 +169,7 @@ def unit_detail(code):
                            user_has_reviewed=user_has_reviewed,
                            is_saved=is_saved,
                            similar_units=similar_units,
-                           rating_dist=rating_dist,
+                           overall_rating_dist=overall_rating_dist,
                            form=form)
 
 # Submit a review

--- a/app/routes.py
+++ b/app/routes.py
@@ -150,6 +150,12 @@ def unit_detail(code):
         Unit.faculty == unit.faculty, Unit.id != unit.id
     ).limit(4).all()
 
+    # Count reviews per star value (1–5) for the Chart.js bar chart
+    rating_dist = [
+        sum(1 for r in reviews_raw if r.overall_rating is not None and r.overall_rating == star)
+        for star in range(1, 6)
+    ]
+
     form = ReviewForm()
 
     return render_template('unit.html',
@@ -163,6 +169,7 @@ def unit_detail(code):
                            user_has_reviewed=user_has_reviewed,
                            is_saved=is_saved,
                            similar_units=similar_units,
+                           rating_dist=rating_dist,
                            form=form)
 
 # Submit a review

--- a/app/static/css/unit.css
+++ b/app/static/css/unit.css
@@ -419,6 +419,12 @@
 
 .sidebar-empty { font-size: .875rem; color: var(--gray-500); }
 
+/* ── Rating distribution chart ──────────────────────────────── */
+#rating-dist-chart {
+  width: 100% !important;
+  max-height: 200px;
+}
+
 /* ── Responsive ─────────────────────────────────────────────── */
 @media (max-width: 960px) {
   .unit-hero       { padding: 24px; flex-direction: column; }

--- a/app/static/js/unit.js
+++ b/app/static/js/unit.js
@@ -93,5 +93,34 @@ $(document).ready(function () {
             }
         });
     });
-
+/* ── Rating distribution chart ─────────────────────────── */
+    var $canvas = $('#rating-dist-chart');
+    if ($canvas.length) {
+        var dist = JSON.parse($canvas.attr('data-dist'));
+        new Chart($canvas[0], {
+            type: 'bar',
+            data: {
+                labels: ['1★', '2★', '3★', '4★', '5★'],
+                datasets: [{
+                    data: dist,
+                    backgroundColor: 'rgba(37, 99, 235, 0.15)',
+                    borderColor:     'rgba(37, 99, 235, 1)',
+                    borderWidth: 1.5,
+                    borderRadius: 4
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: { legend: { display: false } },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: { stepSize: 1, precision: 0 },
+                        grid: { color: 'rgba(0,0,0,0.05)' }
+                    },
+                    x: { grid: { display: false } }
+                }
+            }
+        });
+    }
 });

--- a/app/static/js/unit.js
+++ b/app/static/js/unit.js
@@ -111,7 +111,16 @@ $(document).ready(function () {
             },
             options: {
                 responsive: true,
-                plugins: { legend: { display: false } },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: function(ctx) {
+                                return ctx.parsed.y + ' review' + (ctx.parsed.y !== 1 ? 's' : '');
+                            }
+                        }
+                    }
+                },
                 scales: {
                     y: {
                         beginAtZero: true,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -68,6 +68,9 @@
   <!-- jQuery -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
+  <!-- Chart.js -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -68,9 +68,6 @@
   <!-- jQuery -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
-  <!-- Chart.js -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-  
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -303,7 +303,7 @@
       <div class="sidebar-card">
         <div class="sidebar-card-title">Rating distribution</div>
         <canvas id="rating-dist-chart"
-                data-dist="{{ rating_dist | tojson }}"
+                data-dist="{{ overall_rating_dist | tojson }}"
                 height="160">
         </canvas>
       </div>
@@ -330,5 +330,6 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script src="{{ url_for('static', filename='js/unit.js') }}"></script>
 {% endblock %}

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -299,18 +299,13 @@
         </div>
       </div>
 
-      {% if review_count > 0 %}
+    {% if review_count > 0 %}
       <div class="sidebar-card">
-        <div class="sidebar-card-title">Rating breakdown</div>
-        {% for label, val in [('Overall', avg_overall), ('Workload', avg_workload), ('Difficulty', avg_difficulty), ('Usefulness', avg_usefulness)] %}
-        <div class="sidebar-rating-row">
-          <span class="sidebar-rating-label">{{ label }}</span>
-          <div class="sidebar-rating-bar-track">
-            <div class="sidebar-rating-bar-fill" style="width: {{ (val / 5 * 100)|round }}%"></div>
-          </div>
-          <span class="sidebar-rating-val">{{ val }}</span>
-        </div>
-        {% endfor %}
+        <div class="sidebar-card-title">Rating distribution</div>
+        <canvas id="rating-dist-chart"
+                data-dist="{{ rating_dist | tojson }}"
+                height="160">
+        </canvas>
       </div>
       {% endif %}
 


### PR DESCRIPTION
Add Chart.js rating distribution chart to unit detail page
What this PR does
Adds a visual bar chart to the unit detail sidebar showing how many reviews exist at each star rating (1★ through 5★). Replaces the rating breakdown card which duplicated information already shown in the stats bar above.
Changes

app/routes.py — computes rating_dist (count of reviews per star value 1–5) in unit_detail and passes it to the template
app/templates/base.html — adds Chart.js 4.4.0 via CDN
app/templates/unit.html — replaces rating breakdown sidebar card with rating distribution canvas
app/static/js/unit.js — initialises Chart.js bar chart from canvas data attribute, hidden if no reviews
app/static/css/unit.css — adds sizing rule for the chart canvas

Done when

Unit with reviews shows a bar chart with 5 bars labelled 1★ through 5★
Bar heights reflect actual review counts
Chart is hidden on units with no reviews
Chart uses platform blue colour scheme

How to test

Run python3 run.py and log in
Navigate to any unit that has reviews
Sidebar should show a "Rating distribution" bar chart with 5 bars (1★–5★)
Bar heights should match the actual review counts for that unit
Navigate to a unit with no reviews — chart should not appear


Closes Issue #16 