### PR TITLE
Replace flash banner with reusable toast and remove native browser dialogs

### DIFF
--- a/app/static/css/login.css
+++ b/app/static/css/login.css
@@ -203,13 +203,6 @@
 
 /* ─── Auth alert messages ─────────────────────────────────────────────── */
 /* red */
-.auth-alert {
-  padding: 12px 16px;
-  border-radius: var(--radius-md);
-  font-size: .875rem;
-  font-weight: 500;
-  margin-bottom: 16px;
-}
 .auth-alert-danger  { background: #fef2f2; color: #991b1b; border: 1px solid #fecaca; }
 .auth-alert-success { background: #f0fdf4; color: #166534; border: 1px solid #bbf7d0; }
 .auth-alert-info    { background: #eff6ff; color: #1e40af; border: 1px solid #bfdbfe; }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -115,19 +115,115 @@ a { color: inherit; text-decoration: none; }
 
 .ur-btn-full { width: 100%; }
 
-/* ─── Flash messages ─────────────────────────────────────────── */
-.ur-flash-wrapper { padding: 0 28px; margin-top: 12px; }
-.ur-flash {
-  padding: 10px 16px;
+.ur-btn-danger {
+  background: var(--red-600);
+  color: var(--white);
+  border: 0;
+}
+.ur-btn-danger:hover { background: #872525; }
+
+/* ─── Toast notifications ───────────────────────────────────── */
+/* A single reusable toast component used by both server-side flash()
+   calls and client-side showFlash() in flash.js. Floats over content
+   so it never fights for layout space. */
+.ur-toast-container {
+  position: fixed;
+  top: 76px;                /* sits just below the 56px sticky navbar */
+  right: 20px;
+  z-index: 1000;            /* above modals and sticky elements */
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 360px;
+  width: calc(100% - 40px); /* respects 20px gutters on small screens */
+  pointer-events: none;     /* container ignores clicks; children opt in */
+}
+
+.ur-toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
   border-radius: var(--radius-md);
   font-size: .875rem;
-  margin-bottom: 8px;
+  background: var(--white);
+  box-shadow: var(--shadow-md);
+  border-left: 4px solid var(--gray-500);
+  transform: translateX(120%);
+  opacity: 0;
+  transition: transform var(--transition), opacity var(--transition);
 }
-.ur-flash-info    { background: var(--blue-50);  color: var(--blue-800);  border-left: 4px solid var(--blue-600); }
-.ur-flash-success { background: var(--green-50); color: #085041;          border-left: 4px solid var(--green-600); }
-.ur-flash-error,
-.ur-flash-danger { background: var(--red-50);   color: var(--red-600);   border-left: 4px solid var(--red-600); }
-.ur-flash-warning { background: var(--amber-50); color: #633806;          border-left: 4px solid var(--amber-600); }
+
+.ur-toast.ur-toast-show {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.ur-toast-message {
+  flex: 1;
+  line-height: 1.4;
+  word-wrap: break-word;
+}
+
+.ur-toast-close {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--gray-500);
+  padding: 2px 4px;
+  flex-shrink: 0;
+}
+
+.ur-toast-close:hover { color: var(--gray-900); }
+
+/* Category variants — reuse the same color tokens the old flash used. */
+.ur-toast-info    { background: var(--blue-50);  color: var(--blue-800); border-left-color: var(--blue-600); }
+.ur-toast-success { background: var(--green-50); color: #085041;         border-left-color: var(--green-600); }
+.ur-toast-error,
+.ur-toast-danger  { background: var(--red-50);   color: var(--red-600);  border-left-color: var(--red-600); }
+.ur-toast-warning { background: var(--amber-50); color: #633806;         border-left-color: var(--amber-600); }
+
+/* On narrow screens, center the toast across the top. */
+@media (max-width: 640px) {
+  .ur-toast-container {
+    right: 50%;
+    transform: translateX(50%);
+    top: 68px;
+  }
+}
+
+/* ─── Modal (used by delete-review confirm) ─────────────────── */
+.ur-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.45);
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+.ur-modal-backdrop.ur-modal-show { opacity: 1; }
+
+.ur-modal {
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  max-width: 400px;
+  width: calc(100% - 40px);
+  padding: 24px;
+  transform: scale(.96);
+  transition: transform var(--transition);
+}
+.ur-modal-backdrop.ur-modal-show .ur-modal { transform: scale(1); }
+
+.ur-modal-title { font-size: 1.1rem; font-weight: 600; margin-bottom: 8px; }
+.ur-modal-body  { color: var(--gray-700); margin-bottom: 20px; }
+.ur-modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
 
 /* ─── Score pills ────────────────────────────────────────────── */
 .score-pill {

--- a/app/static/js/flash.js
+++ b/app/static/js/flash.js
@@ -1,0 +1,134 @@
+/**
+ * Reusable toast/flash notification system.
+ *
+ * Exposes a single global function window.showFlash(message, category)
+ * used by:
+ *   - Server-side flash() calls (rendered from base.html on page load)
+ *   - Client-side JS (AJAX failures, form-validation feedback, etc.)
+ *
+ * Categories: 'info', 'success', 'warning', 'danger' (alias: 'error').
+ */
+(function () {
+  'use strict';
+
+  // Lazily create the container on first use, then reuse it.
+  function getContainer() {
+    var container = document.getElementById('ur-toast-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'ur-toast-container';
+      container.className = 'ur-toast-container';
+      // Accessibility: screen readers announce new toasts as they appear.
+      container.setAttribute('role', 'region');
+      container.setAttribute('aria-live', 'polite');
+      container.setAttribute('aria-label', 'Notifications');
+      document.body.appendChild(container);
+    }
+    return container;
+  }
+
+  /**
+   * Show a toast notification.
+   * @param {string} message  - The text to display.
+   * @param {string} category - One of: info, success, warning, danger/error.
+   * @param {number} [duration=4000] - Auto-dismiss after N ms. 0 = persist.
+   */
+  window.showFlash = function (message, category, duration) {
+    category = category || 'info';
+    duration = (typeof duration === 'number') ? duration : 4000;
+
+    var container = getContainer();
+
+    var toast = document.createElement('div');
+    toast.className = 'ur-toast ur-toast-' + category;
+    toast.setAttribute('role', category === 'danger' || category === 'error'
+                               ? 'alert' : 'status');
+
+    var msg = document.createElement('span');
+    msg.className = 'ur-toast-message';
+    msg.textContent = message;   // textContent, not innerHTML — prevents XSS
+
+    var close = document.createElement('button');
+    close.className = 'ur-toast-close';
+    close.setAttribute('aria-label', 'Dismiss notification');
+    close.innerHTML = '&times;';
+    close.onclick = function () { dismiss(toast); };
+
+    toast.appendChild(msg);
+    toast.appendChild(close);
+    container.appendChild(toast);
+
+    // Trigger the slide-in transition on next frame.
+    requestAnimationFrame(function () {
+      toast.classList.add('ur-toast-show');
+    });
+
+    if (duration > 0) {
+      setTimeout(function () { dismiss(toast); }, duration);
+    }
+
+    return toast;
+  };
+
+  function dismiss(toast) {
+    if (!toast || !toast.parentNode) return;
+    toast.classList.remove('ur-toast-show');
+    // Wait for the CSS transition to finish before removing from DOM.
+    setTimeout(function () {
+      if (toast.parentNode) toast.parentNode.removeChild(toast);
+    }, 200);
+  }
+
+  /**
+   * Show a confirmation modal. Returns a Promise that resolves to
+   * true (confirmed) or false (cancelled).
+   * Used by the delete-review flow in Step 6.
+   */
+  window.showConfirm = function (opts) {
+    opts = opts || {};
+    var title       = opts.title       || 'Are you sure?';
+    var body        = opts.body        || '';
+    var confirmText = opts.confirmText || 'Confirm';
+    var cancelText  = opts.cancelText  || 'Cancel';
+    var danger      = !!opts.danger;
+
+    return new Promise(function (resolve) {
+      var backdrop = document.createElement('div');
+      backdrop.className = 'ur-modal-backdrop';
+      backdrop.innerHTML =
+        '<div class="ur-modal" role="dialog" aria-modal="true">' +
+          '<div class="ur-modal-title"></div>' +
+          '<div class="ur-modal-body"></div>' +
+          '<div class="ur-modal-actions">' +
+            '<button type="button" class="ur-btn ur-btn-ghost ur-modal-cancel"></button>' +
+            '<button type="button" class="ur-btn ur-modal-confirm"></button>' +
+          '</div>' +
+        '</div>';
+      document.body.appendChild(backdrop);
+
+      // textContent, not innerHTML — caller-supplied strings are not trusted.
+      backdrop.querySelector('.ur-modal-title').textContent  = title;
+      backdrop.querySelector('.ur-modal-body').textContent   = body;
+      backdrop.querySelector('.ur-modal-cancel').textContent = cancelText;
+      var confirmBtn = backdrop.querySelector('.ur-modal-confirm');
+      confirmBtn.textContent = confirmText;
+      confirmBtn.classList.add(danger ? 'ur-btn-danger' : 'ur-btn-primary');
+
+      function close(result) {
+        backdrop.classList.remove('ur-modal-show');
+        setTimeout(function () {
+          if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop);
+        }, 200);
+        resolve(result);
+      }
+
+      backdrop.querySelector('.ur-modal-cancel').onclick  = function () { close(false); };
+      confirmBtn.onclick                                  = function () { close(true);  };
+      backdrop.onclick = function (e) { if (e.target === backdrop) close(false); };
+
+      requestAnimationFrame(function () {
+        backdrop.classList.add('ur-modal-show');
+      });
+    });
+  };
+})();

--- a/app/static/js/unit.js
+++ b/app/static/js/unit.js
@@ -1,6 +1,48 @@
 /* ─── unit.js ────────────────────────────────────────────────── */
-
 $(document).ready(function () {
+    /* Validate review form before submission — replaces HTML5
+       required/minlength so we can show our own toast instead of
+       the native browser popup. */
+    $(document).on('submit', '#review-form form', function (e) {
+        var $comment = $(this).find('textarea[name="comment"]');
+        var value = ($comment.val() || '').trim();
+
+        if (value.length < 20) {
+            e.preventDefault();
+            window.showFlash(
+                'Please write at least 20 characters in your review.',
+                'warning'
+            );
+            $comment.focus();
+            return false;
+        }
+    });
+
+    /* Confirm delete review via styled modal — replaces the
+       native browser confirm() dialog. */
+    $(document).on('submit', '.js-delete-review-form', function (e) {
+        var $form = $(this);
+
+        // If the form is already flagged as confirmed, let it submit normally.
+        if ($form.data('confirmed')) {
+            return true;
+        }
+
+        e.preventDefault();
+
+        window.showConfirm({
+            title:       'Delete review?',
+            body:        'This will permanently remove your review. This action cannot be undone.',
+            confirmText: 'Delete',
+            cancelText:  'Cancel',
+            danger:      true,
+        }).then(function (confirmed) {
+            if (confirmed) {
+                $form.data('confirmed', true);
+                $form.trigger('submit');
+            }
+        });
+    });
 
     /* Toggle review form */
     $(document).on('click', '.js-toggle-review-form', function (e) {
@@ -15,19 +57,19 @@ $(document).ready(function () {
     /* Edit review button */
     $(document).on('click', '.js-edit-review', function () {
         var reviewId = $(this).data('review-id');
-        var $card    = $('#review-' + reviewId);
+        var $card = $('#review-' + reviewId);
 
         // Read existing values from the review card
-        var overall    = parseInt($card.find('.review-score-badge').text().match(/\d+/)[0]);
-        var miniStats  = $card.find('.review-mini-stat strong');
-        var workload   = parseInt($(miniStats[0]).text());
+        var overall = parseInt($card.find('.review-score-badge').text().match(/\d+/)[0]);
+        var miniStats = $card.find('.review-mini-stat strong');
+        var workload = parseInt($(miniStats[0]).text());
         var difficulty = parseInt($(miniStats[1]).text());
         var usefulness = parseInt($(miniStats[2]).text());
-        var comment    = $card.find('.review-comment').text().trim();
+        var comment = $card.find('.review-comment').text().trim();
 
         // Pre-fill the form
-        $('#slider-overall').val(overall);    $('#val-overall').text(overall);
-        $('#slider-workload').val(workload);   $('#val-workload').text(workload);
+        $('#slider-overall').val(overall); $('#val-overall').text(overall);
+        $('#slider-workload').val(workload); $('#val-workload').text(workload);
         $('#slider-difficulty').val(difficulty); $('#val-difficulty').text(difficulty);
         $('#slider-usefulness').val(usefulness); $('#val-usefulness').text(usefulness);
         $('textarea[name="comment"]').val(comment);
@@ -41,14 +83,14 @@ $(document).ready(function () {
 
     /* ── Vote buttons (upvote / downvote) ──────────────────── */
     $(document).on('click', '.js-vote', function () {
-        var $btn      = $(this);
-        var reviewId  = $btn.data('review-id');
-        var value     = parseInt($btn.data('value'));
-        var isActive  = $btn.attr('data-active') === 'true';
+        var $btn = $(this);
+        var reviewId = $btn.data('review-id');
+        var value = parseInt($btn.data('value'));
+        var isActive = $btn.attr('data-active') === 'true';
         var sendValue = isActive ? 0 : value;
 
         $.ajax({
-            url:    '/api/vote',
+            url: '/api/vote',
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({ review_id: reviewId, value: sendValue }),
@@ -63,18 +105,18 @@ $(document).ready(function () {
                 }
             },
             error: function () {
-                alert('Could not register vote. Please try again.');
+                window.showFlash('Could not register vote. Please try again.', 'danger');
             }
         });
     });
 
     /* ── Save unit button ──────────────────────────────────── */
     $(document).on('click', '.js-save-btn', function () {
-        var $btn   = $(this);
+        var $btn = $(this);
         var unitId = $btn.data('unit-id');
 
         $.ajax({
-            url:    '/api/save-unit',
+            url: '/api/save-unit',
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({ unit_id: unitId }),
@@ -83,17 +125,19 @@ $(document).ready(function () {
                 if (data.saved) {
                     $btn.html('<i class="fa-solid fa-bookmark"></i> Saved');
                     $btn.removeClass('ur-btn-outline').addClass('ur-btn-saved');
+                    window.showFlash('Unit saved to your bookmarks.', 'success');
                 } else {
                     $btn.html('<i class="fa-regular fa-bookmark"></i> Save unit');
                     $btn.removeClass('ur-btn-saved').addClass('ur-btn-outline');
+                    window.showFlash('Unit removed from your bookmarks.', 'info');
                 }
             },
             error: function () {
-                alert('Could not save unit. Please try again.');
+                window.showFlash('Could not save unit. Please try again.', 'danger');
             }
         });
     });
-/* ── Rating distribution chart ─────────────────────────── */
+    /* ── Rating distribution chart ─────────────────────────── */
     var $canvas = $('#rating-dist-chart');
     if ($canvas.length) {
         var dist = JSON.parse($canvas.attr('data-dist'));
@@ -104,7 +148,7 @@ $(document).ready(function () {
                 datasets: [{
                     data: dist,
                     backgroundColor: 'rgba(37, 99, 235, 0.15)',
-                    borderColor:     'rgba(37, 99, 235, 1)',
+                    borderColor: 'rgba(37, 99, 235, 1)',
                     borderWidth: 1.5,
                     borderRadius: 4
                 }]
@@ -115,7 +159,7 @@ $(document).ready(function () {
                     legend: { display: false },
                     tooltip: {
                         callbacks: {
-                            label: function(ctx) {
+                            label: function (ctx) {
                                 return ctx.parsed.y + ' review' + (ctx.parsed.y !== 1 ? 's' : '');
                             }
                         }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -47,32 +47,33 @@
   </nav>
   {% endblock %}
 
-  <!-- Flash messages -->
-  {% block flash_messages %}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-  <div class="ur-flash-wrapper">
-    {% for category, message in messages %}
-    <div class="ur-flash ur-flash-{{ category }}">
-      {{ message }}
-    </div>
-    {% endfor %}
-  </div>
-  {% endif %}
-  {% endwith %}
-  {% endblock %}
-
   <!-- Page content -->
   {% block content %}{% endblock %}
 
-  <!-- jQuery -->
+  <!-- jQuery (must load before flash.js and page scripts) -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 
+  <!-- Reusable flash/toast component — used by both server-side flashes and JS -->
+  <script src="{{ url_for('static', filename='js/flash.js') }}"></script>
+
   <!-- Shared JS -->
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+
+  <!-- Render any server-side flash messages as toasts on page load -->
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      {% for category, message in messages %}
+      window.showFlash({{ message| tojson }}, {{ category| tojson }});
+    {% endfor %}
+        });
+  </script>
+  {% endif %}
+  {% endwith %}
 
   <!-- Page-specific JS -->
   {% block extra_js %}{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -4,8 +4,6 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/login.css') }}">
 {% endblock %}
 
-{% block flash_messages %}{% endblock %}
-
 {% block navbar %}{% endblock %}
 
 {% block content %}
@@ -75,14 +73,6 @@
   <!-- ── Right panel ────────────────────────────── -->
   <div class="login-right">
     <div class="auth-box">
-
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          {% for category, message in messages %}
-            <div class="auth-alert auth-alert-{{ category }}">{{ message }}</div>
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
 
       <h1 class="auth-heading" id="auth-heading">
         {% if show_register %}Create an account{% else %}Welcome back{% endif %}

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -159,7 +159,7 @@
             <label class="form-label">Your review</label>
             <textarea name="comment" class="form-control review-textarea"
                       placeholder="Share your honest experience — what did you learn, how was the workload, any tips for future students?"
-                      rows="4" required minlength="20"></textarea>
+                      rows="4"></textarea>
             <div class="form-hint">Minimum 20 characters.</div>
           </div>
 
@@ -253,8 +253,7 @@
               </button>
               <form method="POST"
                     action="{{ url_for('main.delete_review', review_id=review.id) }}"
-                    class="d-inline"
-                    onsubmit="return confirm('Delete your review?')">
+                    class="d-inline js-delete-review-form">
                 {{ form.hidden_tag() }}
                 <button type="submit" class="review-action-btn review-action-delete">
                   <i class="fa-solid fa-trash"></i> Delete

--- a/tests/selenium/test_user_flow.py
+++ b/tests/selenium/test_user_flow.py
@@ -83,9 +83,9 @@ def test_login_with_wrong_password_shows_error(driver, live_server):
     login_form.find_element(By.NAME, 'password').send_keys('definitely-not-the-right-password')
     login_form.find_element(By.CSS_SELECTOR, 'input[type="submit"]').click()
 
-    # Wait for the flash alert that the login route renders on failure.
+    # Wait for the toast that the login route renders on failure.
     WebDriverWait(driver, 5).until(
-        EC.visibility_of_element_located((By.CSS_SELECTOR, '.auth-alert-danger'))
+        EC.visibility_of_element_located((By.CSS_SELECTOR, '.ur-toast-danger'))
     )
 
     # Should still be on /login (no redirect on failed login).
@@ -93,6 +93,6 @@ def test_login_with_wrong_password_shows_error(driver, live_server):
         f'Expected to remain on /login after wrong password, got: {driver.current_url}'
 
     # The error message text should mention invalid credentials.
-    alert_text = driver.find_element(By.CSS_SELECTOR, '.auth-alert-danger').text
+    alert_text = driver.find_element(By.CSS_SELECTOR, '.ur-toast-danger').text
     assert 'Invalid email or password' in alert_text, \
-        f'Expected "Invalid email or password" alert, got: {alert_text!r}'
+        f'Expected "Invalid email or password" toast, got: {alert_text!r}'


### PR DESCRIPTION
Closes #56 

## Summary

Fixes three related UI issues:

1. Inline flash banner had no space at the top of pages — pushed content down and looked cramped
2. Login page had a duplicate flash implementation (`auth-alert-*`) separate from the base component
3. Native browser dialogs (`alert()`, HTML5 `required minlength`, `confirm()`) broke the design

All three now use one reusable toast component.

## What's new

- **`window.showFlash(message, category)`** — single JS API for toast notifications, used by both server-side `flash()` (via a Jinja bridge in `base.html`) and client-side AJAX handlers
- **`window.showConfirm({title, body, danger})`** — Promise-based styled confirm modal, replacing `confirm()` for destructive actions
- Toast floats top-right (top-center on mobile), auto-dismisses after 4s, has a close button
- Modal has dim backdrop, click-outside-to-close, red confirm button for destructive actions

## Files changed

| File | What |
|---|---|
| `app/static/js/flash.js` | **NEW** — `showFlash()` and `showConfirm()` APIs |
| `app/static/css/main.css` | Replaced `.ur-flash-*` rules with `.ur-toast-*` and `.ur-modal-*` |
| `app/templates/base.html` | Removed inline flash block, added JS bridge for server-side flashes |
| `app/templates/login.html` | Removed duplicate `auth-alert` block |
| `app/templates/unit.html` | Removed `required minlength` on textarea, removed `confirm()` on delete |
| `app/static/js/unit.js` | Replaced 2× `alert()`, added validation handler, added delete modal handler, added save-unit success toasts |
| `app/static/css/login.css` | Removed orphaned `.auth-alert` styles |
| `tests/selenium/test_user_flow.py` | Updated assertion selector to `.ur-toast-danger` |

## How to test

Pull this branch, then:

```bash
# Run all tests — should be 46 passed
pytest tests/ -v
```

**Manual smoke test:**

1. Wrong-password login → red toast top-right, no inline banner
2. Save a unit → green "Unit saved" toast, button changes to "Saved"
3. Try to submit a review with < 20 chars → yellow warning toast, no Chrome popup
4. Delete your own review → styled modal appears (not native confirm dialog)
5. Resize browser to mobile width → toast appears centered at top, fits screen